### PR TITLE
Remove unnecessary pixel writes

### DIFF
--- a/NeoPixel_KnightRider.ino
+++ b/NeoPixel_KnightRider.ino
@@ -84,22 +84,24 @@ void knightRider(uint16_t cycles, uint16_t speed, uint8_t width, uint32_t color)
   // Larson time baby!
   for(int i = 0; i < cycles; i++){
     for (int count = 1; count<NUM_PIXELS; count++) {
-      strip.setPixelColor(count, color); strip.show();
-      delay(speed);
+      strip.setPixelColor(count, color);
       old_val[count] = color;
       for(int x = count; x>0; x--) {
         old_val[x-1] = dimColor(old_val[x-1], width);
-        strip.setPixelColor(x-1, old_val[x-1]); strip.show();
+        strip.setPixelColor(x-1, old_val[x-1]); 
       }
+      strip.show();
+      delay(speed);
     }
     for (int count = NUM_PIXELS-1; count>=0; count--) {
-      strip.setPixelColor(count, color); strip.show();
-      delay(speed);
+      strip.setPixelColor(count, color);
       old_val[count] = color;
       for(int x = count; x<=NUM_PIXELS ;x++) {
         old_val[x-1] = dimColor(old_val[x-1], width);
-        strip.setPixelColor(x+1, old_val[x+1]); strip.show();
+        strip.setPixelColor(x+1, old_val[x+1]);
       }
+      strip.show();
+      delay(speed);
     }
   }
 }


### PR DESCRIPTION
I was testing this with 60 pixels and noticed that the animation would start to lag after about 10 pixels. It's usually best to set all the pixel colors first, then perform one strip.show() to write them all at once inside each loop (rather than writing each pixel one at a time). With the above tweaks made, it's lightning fast now.
